### PR TITLE
Suggest Storage lib

### DIFF
--- a/racoon-commons/src/main/java/run/racoon/commons/storage/Storage.java
+++ b/racoon-commons/src/main/java/run/racoon/commons/storage/Storage.java
@@ -1,6 +1,6 @@
-package run.racoon.storage;
+package run.racoon.commons.storage;
 
-public interface Storage {
+public interface Storage extends AutoCloseable {
     void put(String key, Object value);
     <T> T get(String key);
     boolean hasKey(String key);

--- a/racoon-commons/src/main/java/run/racoon/commons/storage/configuration/Configuration.java
+++ b/racoon-commons/src/main/java/run/racoon/commons/storage/configuration/Configuration.java
@@ -1,4 +1,4 @@
-package run.racoon.storage.configuration;
+package run.racoon.commons.storage.configuration;
 
 import java.util.List;
 

--- a/racoon-commons/src/main/java/run/racoon/commons/storage/serialization/ValueDeserializer.java
+++ b/racoon-commons/src/main/java/run/racoon/commons/storage/serialization/ValueDeserializer.java
@@ -1,4 +1,4 @@
-package run.racoon.storage.serialization;
+package run.racoon.commons.storage.serialization;
 
 public interface ValueDeserializer {
     <T> T deserialize(byte[] value);

--- a/racoon-commons/src/main/java/run/racoon/commons/storage/serialization/ValueSerializer.java
+++ b/racoon-commons/src/main/java/run/racoon/commons/storage/serialization/ValueSerializer.java
@@ -1,4 +1,4 @@
-package run.racoon.storage.serialization;
+package run.racoon.commons.storage.serialization;
 
 public interface ValueSerializer {
     byte[] serialize(Object value);

--- a/racoon-node/build.gradle
+++ b/racoon-node/build.gradle
@@ -10,18 +10,18 @@ repositories {
 }
 
 dependencies {
-    compile project(':racoon-storage')
+    implementation project(':racoon-storage')
 
-    compile 'com.beust:jcommander:1.72'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.7'
-    compile 'org.apache.logging.log4j:log4j-api:2.11.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.11.1'
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.11.1'
+    implementation 'com.beust:jcommander:1.72'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.7'
+    implementation 'org.apache.logging.log4j:log4j-api:2.11.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.11.1'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.11.1'
    
-    compile 'org.pojomatic:pojomatic:2.2.1'
+    implementation 'org.pojomatic:pojomatic:2.2.1'
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 configurations.all {

--- a/racoon-storage/build.gradle
+++ b/racoon-storage/build.gradle
@@ -10,5 +10,6 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation project(':racoon-commons')
+    implementation 'net.openhft:chronicle-map:3.17.0'
 }

--- a/racoon-storage/src/main/java/run/racoon/storage/StorageFactory.java
+++ b/racoon-storage/src/main/java/run/racoon/storage/StorageFactory.java
@@ -1,6 +1,7 @@
 package run.racoon.storage;
 
-import run.racoon.storage.configuration.Configuration;
+import run.racoon.commons.storage.Storage;
+import run.racoon.commons.storage.configuration.Configuration;
 import run.racoon.storage.serialization.ProtobufDeserializer;
 import run.racoon.storage.serialization.ProtobufSerializer;
 

--- a/racoon-storage/src/main/java/run/racoon/storage/configuration/RacoonStorageConfiguration.java
+++ b/racoon-storage/src/main/java/run/racoon/storage/configuration/RacoonStorageConfiguration.java
@@ -1,20 +1,30 @@
 package run.racoon.storage.configuration;
 
+import run.racoon.commons.storage.configuration.Configuration;
+
 import java.util.List;
 import java.util.Objects;
 
 public class RacoonStorageConfiguration implements Configuration {
     public static final String NODES_PROPERTY = "nodes";
+    public static final String NODE_IDENTIFIER = "identifier";
 
     private final List<DataNode> dataNodes;
+    private final String nodeIdentifier;
 
-    public RacoonStorageConfiguration(List<DataNode> dataNodes) {
+    public RacoonStorageConfiguration(List<DataNode> dataNodes, String nodeIdentifier) {
         this.dataNodes = Objects.requireNonNull(dataNodes, "Data nodes cannot be null");
+        this.nodeIdentifier = nodeIdentifier;
     }
 
     @Override
     public <T> T getByKey(String key) {
-        throw new NullPointerException("Key not found: " + key);
+        switch (key) {
+            case NODE_IDENTIFIER:
+                return (T) nodeIdentifier;
+            default:
+                throw new NullPointerException("Key not found: " + key);
+        }
     }
 
     @Override

--- a/racoon-storage/src/main/java/run/racoon/storage/serialization/ProtobufDeserializer.java
+++ b/racoon-storage/src/main/java/run/racoon/storage/serialization/ProtobufDeserializer.java
@@ -1,5 +1,7 @@
 package run.racoon.storage.serialization;
 
+import run.racoon.commons.storage.serialization.ValueDeserializer;
+
 public class ProtobufDeserializer implements ValueDeserializer {
     @Override
     public <T> T deserialize(byte[] value) {

--- a/racoon-storage/src/main/java/run/racoon/storage/serialization/ProtobufSerializer.java
+++ b/racoon-storage/src/main/java/run/racoon/storage/serialization/ProtobufSerializer.java
@@ -1,5 +1,7 @@
 package run.racoon.storage.serialization;
 
+import run.racoon.commons.storage.serialization.ValueSerializer;
+
 public class ProtobufSerializer implements ValueSerializer {
     @Override
     public byte[] serialize(Object value) {


### PR DESCRIPTION
ChronicleMap has its own replication, sadly it is available only for enterprise edition. 
We could try reimplement our own replication, based on their description https://github.com/OpenHFT/Chronicle-Map/blob/master/docs/CM_Replication.adoc

@Minutis what do you think?

Also moved all interface classes to commons module, to make it possible to extend system with minimal racoon dependency footprint.